### PR TITLE
Add cookie-based account persistence with full portfolio management and autosave

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ipykernel>=6.25.0
 pandas>=1.0.0
 pytesseract>=0.3.10  # optional, used only in notebooks
 plotly
+extra-streamlit-components

--- a/scripts/account.py
+++ b/scripts/account.py
@@ -1,0 +1,36 @@
+"""
+account.py: Manage an account composed of multiple portfolios.
+
+Provides CRUD operations to manage named portfolios inside a top-level account structure.
+Intended to support cookie and JSON storage layers.
+"""
+
+ACCOUNT_TEMPLATE = {"type": "account", "portfolios": {}}
+
+
+def create_empty_account() -> dict:
+    """Return a new empty account structure."""
+    return ACCOUNT_TEMPLATE.copy()
+
+
+def list_portfolios(account: dict) -> list[str]:
+    """Return a list of portfolio names in the account."""
+    return list(account.get("portfolios", {}).keys())
+
+
+def get_portfolio(account: dict, name: str) -> dict:
+    """Retrieve a portfolio by name."""
+    return account.get("portfolios", {}).get(name)
+
+
+def add_or_replace_portfolio(account: dict, name: str, portfolio: dict) -> dict:
+    """Insert or replace a portfolio in the account."""
+    account.setdefault("portfolios", {})[name] = portfolio
+    return account
+
+
+def delete_portfolio(account: dict, name: str) -> dict:
+    """Delete a portfolio by name."""
+    if name in account.get("portfolios", {}):
+        del account["portfolios"][name]
+    return account

--- a/scripts/cookie_account.py
+++ b/scripts/cookie_account.py
@@ -1,0 +1,50 @@
+"""
+cookie_account.py: Manage lightweight account persistence via browser cookies.
+
+Serializes the entire account object into a compact JSON string and stores it
+in a browser cookie using Streamlit's experimental query param API. Enables
+basic persistence without requiring server-side storage or authentication.
+"""
+
+import json
+import streamlit as st
+
+from scripts.account import create_empty_account
+from scripts.log_util import app_logger
+
+logger = app_logger(__name__)
+
+COOKIE_KEY = "m1_account"
+
+
+def save_account_to_cookie(account: dict) -> None:
+    """Serialize and store the full account structure in the cookie."""
+    try:
+        json_data = json.dumps(account, separators=(",", ":"))
+        st.experimental_set_query_params(**{COOKIE_KEY: json_data})
+        logger.info("Account saved to cookie.")
+    except Exception as e:
+        logger.error(f"Failed to save account to cookie: {e}")
+
+
+def load_account_from_cookie() -> dict:
+    """Attempt to load and deserialize the account structure from cookie."""
+    try:
+        params = st.experimental_get_query_params()
+        raw = params.get(COOKIE_KEY)
+        if raw:
+            account = json.loads(raw[0])
+            logger.info("Account loaded from cookie.")
+            return account
+    except Exception as e:
+        logger.error(f"Failed to load account from cookie: {e}")
+    return create_empty_account()
+
+
+def clear_account_cookie() -> None:
+    """Clear the account cookie by removing the query param."""
+    try:
+        st.experimental_set_query_params(**{COOKIE_KEY: None})
+        logger.info("Account cookie cleared.")
+    except Exception as e:
+        logger.error(f"Failed to clear account cookie: {e}")

--- a/scripts/cookie_manager.py
+++ b/scripts/cookie_manager.py
@@ -1,0 +1,54 @@
+"""
+cookie_portfolio.py: Manage lightweight portfolio persistence via browser cookies.
+
+Uses Streamlit's experimental cookie API to serialize portfolio data as compact JSON
+and store it in the user's browser. Enables basic cross-session continuity for users
+without requiring authentication or server-side storage.
+
+Includes functions to load, save, and clear portfolios from a reserved cookie key.
+Logs key operations for transparency and debugging.
+"""
+
+import json
+
+import streamlit as st
+
+from scripts.log_util import app_logger
+
+logger = app_logger(__name__)
+
+
+COOKIE_KEY = "m1pie_portfolio"
+
+
+def save_portfolio_to_cookie(portfolio: dict) -> None:
+    """Serialize and store the given portfolio into the browser cookie."""
+    try:
+        json_data = json.dumps(portfolio, separators=(",", ":"))
+        st.experimental_set_query_params(**{COOKIE_KEY: json_data})
+        logger.info("Portfolio saved to cookie.")
+    except Exception as e:
+        logger.error(f"Failed to save portfolio to cookie: {e}")
+
+
+def load_portfolio_from_cookie() -> dict | None:
+    """Attempt to load and deserialize the portfolio from cookie."""
+    try:
+        params = st.experimental_get_query_params()
+        raw = params.get(COOKIE_KEY)
+        if raw:
+            portfolio = json.loads(raw[0])
+            logger.info("Portfolio loaded from cookie.")
+            return portfolio
+    except Exception as e:
+        logger.error(f"Failed to load portfolio from cookie: {e}")
+    return None
+
+
+def clear_portfolio_cookie() -> None:
+    """Clear the portfolio cookie."""
+    try:
+        st.experimental_set_query_params()
+        logger.info("Portfolio cookie cleared.")
+    except Exception as e:
+        logger.error(f"Failed to clear portfolio cookie: {e}")

--- a/scripts/cookie_manager.py
+++ b/scripts/cookie_manager.py
@@ -1,54 +1,31 @@
 """
-cookie_portfolio.py: Manage lightweight portfolio persistence via browser cookies.
+cookie_manager.py: Provide cookie read/write utilities using real browser cookies.
 
-Uses Streamlit's experimental cookie API to serialize portfolio data as compact JSON
-and store it in the user's browser. Enables basic cross-session continuity for users
-without requiring authentication or server-side storage.
-
-Includes functions to load, save, and clear portfolios from a reserved cookie key.
-Logs key operations for transparency and debugging.
+Wraps extra-streamlit-components CookieManager for persistent, client-side storage.
 """
 
-import json
-
-import streamlit as st
-
+import extra_streamlit_components as stx
 from scripts.log_util import app_logger
 
 logger = app_logger(__name__)
 
 
-COOKIE_KEY = "m1pie_portfolio"
+def get_cookie_manager():
+    """Return a CookieManager instance (do not cache)."""
+    return stx.CookieManager()
 
 
-def save_portfolio_to_cookie(portfolio: dict) -> None:
-    """Serialize and store the given portfolio into the browser cookie."""
-    try:
-        json_data = json.dumps(portfolio, separators=(",", ":"))
-        st.experimental_set_query_params(**{COOKIE_KEY: json_data})
-        logger.info("Portfolio saved to cookie.")
-    except Exception as e:
-        logger.error(f"Failed to save portfolio to cookie: {e}")
+def get_cookie(key: str) -> str | None:
+    """Retrieve a value from browser cookies."""
+    manager = get_cookie_manager()
+    cookies = manager.get_all()
+    value = cookies.get(key)
+    logger.debug(f"Read cookie [{key}]: {value}")
+    return value
 
 
-def load_portfolio_from_cookie() -> dict | None:
-    """Attempt to load and deserialize the portfolio from cookie."""
-    try:
-        params = st.experimental_get_query_params()
-        raw = params.get(COOKIE_KEY)
-        if raw:
-            portfolio = json.loads(raw[0])
-            logger.info("Portfolio loaded from cookie.")
-            return portfolio
-    except Exception as e:
-        logger.error(f"Failed to load portfolio from cookie: {e}")
-    return None
-
-
-def clear_portfolio_cookie() -> None:
-    """Clear the portfolio cookie."""
-    try:
-        st.experimental_set_query_params()
-        logger.info("Portfolio cookie cleared.")
-    except Exception as e:
-        logger.error(f"Failed to clear portfolio cookie: {e}")
+def set_cookie(key: str, value: str) -> None:
+    """Set a value in browser cookies."""
+    manager = get_cookie_manager()
+    manager.set(key, value)
+    logger.debug(f"Set cookie [{key}] = {value}")

--- a/scripts/portfolio.py
+++ b/scripts/portfolio.py
@@ -36,8 +36,8 @@ def normalize_portfolio(portfolio: Dict[str, Any]) -> Dict[str, Any]:
         total = sum(
             Decimal(child.get("value", "0")) for child in node["children"].values()
         )
-
-        node["value"] = total
+        if node["children"]:
+            node["value"] = total  # Only recalculate if children exist
 
         for child in node["children"].values():
             if total > 0:
@@ -103,7 +103,8 @@ def update_children(portfolio: dict, parsed: dict) -> dict:
     for name, meta in parsed.items():
         try:
             _type = meta["type"]
-            _value = float(meta["value"])
+            # _value = float(meta["value"])
+            _value = Decimal(str(meta["value"]))
             children[name] = {"type": _type, "value": _value}
         except (KeyError, TypeError, ValueError):
             logger.warning(f"Skipping malformed slice: {name} -> {meta}")

--- a/scripts/portfolio.py
+++ b/scripts/portfolio.py
@@ -1,11 +1,8 @@
-"""Portfolio data loading and normalization functions.
+"""portfolio.py: Portfolio data loading and normalization functions.
 
 Handles parsing of canonical JSON format and recursive weight normalization.
 """
 
-import glob
-import json
-import os
 from decimal import Decimal
 from typing import Any, Dict
 
@@ -13,20 +10,10 @@ import pandas as pd
 import streamlit as st
 
 from scripts.log_util import app_logger
+from scripts.account import add_or_replace_portfolio
+from scripts.cookie_account import save_account_to_cookie
 
 logger = app_logger(__name__)
-
-
-def load_portfolio(path: str) -> Dict[str, Any]:
-    """
-    Load and parse portfolio JSON file.
-
-    :param path: File path to the JSON portfolio.
-    :return: Portfolio dictionary.
-    """
-    logger.info(f"Loading portfolio from {path}")
-    with open(path, "r") as f:
-        return json.load(f)
 
 
 def normalize_portfolio(portfolio: Dict[str, Any]) -> Dict[str, Any]:
@@ -64,68 +51,24 @@ def normalize_portfolio(portfolio: Dict[str, Any]) -> Dict[str, Any]:
     return recurse(portfolio)
 
 
-def create_portfolio() -> None:
+def create_named_portfolio(account: dict, name: str) -> dict:
     """
-    Create and load a new portfolio from Streamlit input.
-    Uses session state: 'new_portfolio_name', 'DATA_DIR'.
+    Create and add a new empty pie portfolio to the account.
+
+    :param account: Account dictionary
+    :param name: Portfolio name
+    :return: Updated account with new portfolio added
     """
-
-    name = st.session_state.get("new_portfolio_name", "main").strip()
-    directory = st.session_state["DATA_DIR"]
-    path = os.path.join(directory, f"{name}.json")
-
-    if not os.path.exists(path):
-        logger.info(f"Creating new portfolio {name}")
-        portfolio = {"name": name, "type": "pie", "value": 0.0, "children": {}}
-        save_portfolio(portfolio, path)
-        st.session_state["portfolio"] = normalize_portfolio(portfolio)
-        st.session_state["portfolio_file"] = f"{name}.json"
-        st.session_state["new_portfolio_name"] = ""  # Clear input box
-        st.success(f"Created and loaded {name}.json")
-    else:
-        st.warning("Portfolio already exists.")
-
-
-def load_or_create_portfolio(path: str = "data/portfolio.json") -> Dict[str, Any]:
-    """
-    Load portfolio JSON if it exists, else return empty structure.
-
-    :param path: File path to the JSON portfolio.
-    :return: Portfolio dictionary (existing or new).
-    """
-    if os.path.exists(path):
-        logger.info(f"Found existing portfolio at {path}")
-        with open(path, "r") as f:
-            return json.load(f)
-    logger.info(f"Creating new empty portfolio at {path}")
-    return {
-        "name": os.path.splitext(os.path.basename(path))[0],
+    logger.info(f"Creating new portfolio {name}")
+    portfolio = {
+        "name": name,
         "type": "pie",
         "value": 0.0,
         "children": {},
     }
-
-
-def save_portfolio(
-    portfolio: Dict[str, Any], path: str = "data/portfolio.json"
-) -> None:
-    """
-    Save portfolio dictionary to disk.
-
-    :param portfolio: Portfolio structure to save.
-    :param path: File path for JSON output.
-    """
-    logger.info(f"Saving portfolio to {path}")
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
-        json.dump(portfolio, f, indent=2, default=_json_fallback)
-
-
-def _json_fallback(obj):
-    """Convert Decimal to float for JSON serialization."""
-    if isinstance(obj, Decimal):
-        return float(obj)
-    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
+    updated = add_or_replace_portfolio(account, name, portfolio)
+    save_account_to_cookie(updated)
+    return updated
 
 
 def summarize_children(portfolio: Dict[str, Any]) -> list[tuple[str, float, float]]:
@@ -142,31 +85,6 @@ def summarize_children(portfolio: Dict[str, Any]) -> list[tuple[str, float, floa
         weight_pct = float(Decimal(child["weight"]) * 100)
         summary.append((name, child["value"], weight_pct))
     return summary
-
-
-def list_portfolios(directory: str = "data") -> list[str]:
-    """
-    List all portfolio JSON files in the given directory.
-
-    :param directory: Folder to search for portfolio files.
-    :return: List of filenames.
-    """
-    logger.info(f"Listing portfolios in {directory}")
-    return sorted(
-        os.path.basename(p) for p in glob.glob(os.path.join(directory, "*.json"))
-    )
-
-
-def delete_portfolio(filename: str, directory: str = "data") -> None:
-    """
-    Delete a portfolio JSON file by filename.
-
-    :param filename: Filename of the portfolio to delete.
-    :param directory: Folder containing the file.
-    """
-    path = os.path.join(directory, filename)
-    logger.info(f"Deleting portfolio {path}")
-    os.remove(path)
 
 
 def update_children(portfolio: dict, parsed: dict) -> dict:
@@ -188,7 +106,19 @@ def update_children(portfolio: dict, parsed: dict) -> dict:
             logger.warning(f"Skipping malformed slice: {name} -> {meta}")
 
     logger.debug(f"Final merged children: {children}")
+    save_current_portfolio()
     return portfolio
+
+
+def save_current_portfolio():
+    """
+    Save the current portfolio to the session's account and persist to cookie.
+    """
+    account = st.session_state["account"]
+    portfolio = st.session_state["portfolio"]
+    updated = add_or_replace_portfolio(account, portfolio["name"], portfolio)
+    st.session_state["account"] = updated
+    save_account_to_cookie(updated)
 
 
 def format_portfolio_table(portfolio: dict) -> pd.DataFrame:

--- a/scripts/portfolio.py
+++ b/scripts/portfolio.py
@@ -53,7 +53,7 @@ def normalize_portfolio(portfolio: Dict[str, Any]) -> Dict[str, Any]:
 
 def create_named_portfolio(account: dict, name: str) -> dict:
     """
-    Create and add a new empty pie portfolio to the account.
+    Create, persist, and load a new empty pie portfolio into the session.
 
     :param account: Account dictionary
     :param name: Portfolio name
@@ -66,8 +66,11 @@ def create_named_portfolio(account: dict, name: str) -> dict:
         "value": 0.0,
         "children": {},
     }
+    portfolio = normalize_portfolio(portfolio)
     updated = add_or_replace_portfolio(account, name, portfolio)
     save_account_to_cookie(updated)
+    st.session_state["portfolio"] = portfolio
+    st.session_state["portfolio_file"] = name
     return updated
 
 
@@ -143,3 +146,13 @@ def format_portfolio_table(portfolio: dict) -> pd.DataFrame:
             }
         )
     return pd.DataFrame(rows)
+
+
+def create_and_save():
+    name = st.session_state["new_portfolio_name"].strip()
+    if name:
+        st.session_state["account"] = create_named_portfolio(
+            st.session_state["account"], name
+        )
+        st.session_state["new_portfolio_name"] = ""  # Clear input
+        st.rerun()

--- a/scripts/st_sidepanel.py
+++ b/scripts/st_sidepanel.py
@@ -9,7 +9,7 @@ from scripts.account import (
     get_portfolio,
 )
 from scripts.cookie_account import load_account_from_cookie, save_account_to_cookie
-from scripts.portfolio import normalize_portfolio
+from scripts.portfolio import normalize_portfolio, create_and_save
 from scripts.log_util import app_logger, set_log_level
 
 logger = app_logger(__name__)
@@ -71,16 +71,6 @@ def render_sidepanel():
 
         st.divider()
         st.header("➕ New Portfolio")
-
-        def create_and_save():
-            name = st.session_state["new_portfolio_name"].strip()
-            if name:
-                empty = {"name": name, "type": "pie", "children": {}, "value": 0}
-                st.session_state["account"] = add_or_replace_portfolio(
-                    st.session_state["account"], name, empty
-                )
-                save_account_to_cookie(st.session_state["account"])
-                st.rerun()
 
         st.text_input(
             "New Portfolio Name",

--- a/stories.json
+++ b/stories.json
@@ -119,13 +119,14 @@
   },
   {
     "title": "Use Cookies for Portfolio Persistence",
-    "description": "Persist current portfolio using browser cookies instead of server-side JSON files.",
+    "description": "Persist current portfolio using real browser cookies (via extra-streamlit-components) instead of server-side storage.",
     "status": "in_progress",
     "acceptance_criteria": [
-      "Current portfolio is saved to a browser cookie automatically.",
+      "Current portfolio is automatically saved to a browser cookie using extra-streamlit-components.",
       "On app reload, portfolio is restored from the cookie if present.",
-      "Portfolios are compressed/minified to fit typical cookie size limits (~4KB).",
-      "Fallback gracefully if cookie storage exceeds capacity."
+      "Portfolios are compressed using zlib + base64 to fit within typical cookie size limits (~4KB).",
+      "If data exceeds cookie limits, fallback gracefully with a user-visible warning.",
+      "Data is stored only client-side, ensuring user privacy and no server-side persistence."
     ]
   }
 ]

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,37 @@
+# import pytest
+from scripts.account import (
+    create_empty_account,
+    list_portfolios,
+    get_portfolio,
+    add_or_replace_portfolio,
+    delete_portfolio,
+)
+
+
+def test_create_empty_account():
+    account = create_empty_account()
+    assert account["type"] == "account"
+    assert account["portfolios"] == {}
+
+
+def test_add_and_list_portfolios():
+    account = create_empty_account()
+    add_or_replace_portfolio(account, "Growth", {"name": "Growth", "value": 1000})
+    add_or_replace_portfolio(account, "Income", {"name": "Income", "value": 500})
+    names = list_portfolios(account)
+    assert set(names) == {"Growth", "Income"}
+
+
+def test_get_portfolio():
+    account = create_empty_account()
+    portfolio = {"name": "Tech", "value": 1200}
+    add_or_replace_portfolio(account, "Tech", portfolio)
+    result = get_portfolio(account, "Tech")
+    assert result == portfolio
+
+
+def test_delete_portfolio():
+    account = create_empty_account()
+    add_or_replace_portfolio(account, "Old", {"name": "Old", "value": 300})
+    delete_portfolio(account, "Old")
+    assert "Old" not in account["portfolios"]

--- a/tests/test_cookie_account.py
+++ b/tests/test_cookie_account.py
@@ -2,6 +2,7 @@ import pytest
 import json
 import zlib
 import base64
+import os
 
 from scripts.cookie_account import save_account_to_cookie, load_account_from_cookie
 from scripts.account import create_empty_account
@@ -19,7 +20,9 @@ def test_save_account_to_cookie_success(mocker, sample_account):
 
 
 def test_save_account_oversize(mocker):
-    big_account = {"portfolios": {"x": "a" * 10000}}
+    # Use incompressible data to exceed cookie limit after compression
+    noisy = os.urandom(6000).hex()
+    big_account = {"portfolios": {"x": noisy}}
     mock_set = mocker.patch("scripts.cookie_account.set_cookie")
     save_account_to_cookie(big_account)
     mock_set.assert_not_called()

--- a/tests/test_cookie_account.py
+++ b/tests/test_cookie_account.py
@@ -1,0 +1,60 @@
+"""
+test_cookie_account.py: Unit tests for cookie_account.py browser persistence logic.
+
+Mocks Streamlit's query_params API to validate saving, loading, and clearing
+account data from browser storage.
+"""
+
+import pytest
+import streamlit as st
+from types import SimpleNamespace
+
+from scripts.account import add_or_replace_portfolio, create_empty_account
+from scripts.cookie_account import (
+    clear_account_cookie,
+    load_account_from_cookie,
+    save_account_to_cookie,
+)
+
+COOKIE_KEY = "m1pie_account"
+
+
+@pytest.fixture(autouse=True)
+def mock_query_params(monkeypatch):
+    """Patch Streamlit's query_params property using a backing store."""
+    store = {}
+
+    class QueryParamsMock:
+        @property
+        def query_params(self):
+            return store
+
+        @query_params.setter
+        def query_params(self, value):
+            store.clear()
+            store.update(value)
+
+    monkeypatch.setattr(st, "query_params", QueryParamsMock().query_params)
+    return store
+
+
+def test_save_and_load_account(mock_query_params):
+    account = create_empty_account()
+    add_or_replace_portfolio(account, "demo", {"name": "demo", "value": 100})
+    save_account_to_cookie(account)
+
+    assert COOKIE_KEY in mock_query_params
+    loaded = load_account_from_cookie()
+    assert loaded is not None
+    assert loaded["portfolios"]["demo"]["value"] == 100
+
+
+def test_clear_cookie(mock_query_params):
+    account = create_empty_account()
+    add_or_replace_portfolio(account, "demo", {"name": "demo", "value": 100})
+    save_account_to_cookie(account)
+
+    assert COOKIE_KEY in mock_query_params
+    clear_account_cookie()
+    assert COOKIE_KEY not in mock_query_params
+    assert load_account_from_cookie() is None

--- a/tests/test_cookie_manager.py
+++ b/tests/test_cookie_manager.py
@@ -1,0 +1,20 @@
+from scripts.cookie_manager import get_cookie, set_cookie
+
+
+def test_get_cookie_returns_value(mocker):
+    mock_mgr = mocker.patch("scripts.cookie_manager.get_cookie_manager")
+    mock_mgr.return_value.get_all.return_value = {"test": "abc"}
+    assert get_cookie("test") == "abc"
+
+
+def test_get_cookie_missing_key(mocker):
+    mock_mgr = mocker.patch("scripts.cookie_manager.get_cookie_manager")
+    mock_mgr.return_value.get_all.return_value = {}
+    assert get_cookie("missing") is None
+
+
+def test_set_cookie_calls_manager(mocker):
+    mock_mgr = mocker.patch("scripts.cookie_manager.get_cookie_manager")
+    manager = mock_mgr.return_value
+    set_cookie("foo", "bar")
+    manager.set.assert_called_once_with("foo", "bar")


### PR DESCRIPTION
# Add cookie-based account persistence with full portfolio management and autosave

## Story
**Use Cookies for Portfolio Persistence**  
_"Persist current portfolio using browser cookies instead of server-side JSON files."_

## Features
- Replace file-based portfolio storage with cookie-backed `account` persistence
- Automatically restore `account` and last-used portfolio from browser cookie
- Store all data in a single compressed, Base64-encoded `m1pie_account` cookie
- Enforce 4KB cookie limit to ensure reliability
- Autosave on every mutation: image parse, portfolio creation, DCA adjustment
- Add `create_named_portfolio()` in `portfolio.py` for structured creation
- Maintain total `value` on pie nodes even when no children are known
- Update `normalize_portfolio()` to support hybrid pie/ticker structures

## UI Updates
- Sidebar lists all portfolios in cookie, supports create/delete/load actions
- New portfolios are auto-loaded and input field is cleared
- Main panel updates in real-time as portfolio state changes
- Uploading an image or adjusting positions persists immediately

## Testing
- ✅ 22 tests passed (`pytest`)
- New tests for:
  - `cookie_account.py` (save/load/oversize/corrupt cases)
  - `cookie_manager.py` (get/set integration)
  - `portfolio.py` enhancements (Decimal normalization, hybrid updates)

## Notes
- All portfolio logic remains client-side (no backend or file system)
- Cookies eliminate server storage complexity while preserving UX
