### PR TITLE
Add Ko-fi Support Button to Sidebar

### DIFF
--- a/scripts/st_sidepanel.py
+++ b/scripts/st_sidepanel.py
@@ -8,7 +8,7 @@ from scripts.account import (
     list_portfolios,
 )
 from scripts.cookie_account import load_account_from_cookie, save_account_to_cookie
-from scripts.log_util import app_logger, set_log_level
+from scripts.log_util import app_logger  # , set_log_level -- add this if for ux control
 from scripts.portfolio import (
     create_and_save,
     make_example_portfolio,
@@ -87,14 +87,16 @@ def render_sidepanel():
             make_example_portfolio()
 
         st.divider()
-        st.header("🛠️ Settings")
-
-        log_level = st.selectbox(
-            "Log Level",
-            options=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-            index=1,
-            key="log_level",
-        )
-        set_log_level(log_level)
-        st.caption(f"Logger set to {log_level}")
         render_support_link()
+
+        # comment the settions options. this is more of a dev thing...
+        # st.header("🛠️ Settings")
+        #
+        # log_level = st.selectbox(
+        #     "Log Level",
+        #     options=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        #     index=1,
+        #     key="log_level",
+        # )
+        # set_log_level(log_level)
+        # st.caption(f"Logger set to {log_level}")

--- a/scripts/st_sidepanel.py
+++ b/scripts/st_sidepanel.py
@@ -14,6 +14,7 @@ from scripts.portfolio import (
     make_example_portfolio,
     normalize_portfolio,
 )
+from scripts.st_utils import render_support_link
 
 logger = app_logger(__name__)
 
@@ -96,3 +97,4 @@ def render_sidepanel():
         )
         set_log_level(log_level)
         st.caption(f"Logger set to {log_level}")
+        render_support_link()

--- a/scripts/st_sidepanel.py
+++ b/scripts/st_sidepanel.py
@@ -87,6 +87,7 @@ def render_sidepanel():
             make_example_portfolio()
 
         st.divider()
+
         render_support_link()
 
         # comment the settions options. this is more of a dev thing...
@@ -100,3 +101,4 @@ def render_sidepanel():
         # )
         # set_log_level(log_level)
         # st.caption(f"Logger set to {log_level}")
+        #

--- a/scripts/st_utils.py
+++ b/scripts/st_utils.py
@@ -5,8 +5,8 @@ Contains reusable components for visualizing portfolio adjustments,
 such as allocation review tables comparing current and target states.
 """
 
-from decimal import Decimal, InvalidOperation
 import random
+from decimal import Decimal, InvalidOperation
 
 import pandas as pd
 import plotly.graph_objects as go
@@ -219,22 +219,21 @@ def render_sankey_diagram(portfolio: dict) -> None:
 
 
 def render_support_link():
-    """Render a support button linking to Ko-fi or similar.
+    """Render a support button linking to Ko-fi or similar."""
+    if "support_label" not in st.session_state:
+        st.session_state.support_label = random.choice(
+            [
+                "☕ Support on Ko-fi",
+                "💖 Buy me a coffee",
+                "🙏 Tip the dev",
+                "🍩 Donate via Ko-fi",
+                "❤️ Send a thank-you",
+            ]
+        )
 
-    Set the donation URL via .streamlit/secrets.toml:
-    [support]
-    kofi_url = "https://ko-fi.com/yourhandle"
-    """
     kofi_url = st.secrets.get("support", {}).get("kofi_url")
     if kofi_url:
-        labels = [
-            "\u2615 Support on Ko-fi",
-            "\ud83d\udc96 Buy me a coffee",
-            "\ud83d\ude4f Tip the dev",
-            "\ud83c\udf69 Donate via Ko-fi",
-            "\u2764\ufe0f Send a thank-you",
-        ]
-        st.sidebar.link_button(random.choice(labels), kofi_url)
+        st.sidebar.link_button(st.session_state.support_label, kofi_url)
     else:
         logger.warning(
             "No support.kofi_url found in st.secrets; support button not shown."

--- a/scripts/st_utils.py
+++ b/scripts/st_utils.py
@@ -6,11 +6,16 @@ such as allocation review tables comparing current and target states.
 """
 
 from decimal import Decimal, InvalidOperation
+import random
 
 import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 from plotly.colors import qualitative
+
+from scripts.log_util import app_logger
+
+logger = app_logger(__name__)
 
 
 def render_allocation_review_table(original: dict, adjusted: dict) -> None:
@@ -211,3 +216,26 @@ def render_sankey_diagram(portfolio: dict) -> None:
     )
 
     st.plotly_chart(fig, use_container_width=True)
+
+
+def render_support_link():
+    """Render a support button linking to Ko-fi or similar.
+
+    Set the donation URL via .streamlit/secrets.toml:
+    [support]
+    kofi_url = "https://ko-fi.com/yourhandle"
+    """
+    kofi_url = st.secrets.get("support", {}).get("kofi_url")
+    if kofi_url:
+        labels = [
+            "\u2615 Support on Ko-fi",
+            "\ud83d\udc96 Buy me a coffee",
+            "\ud83d\ude4f Tip the dev",
+            "\ud83c\udf69 Donate via Ko-fi",
+            "\u2764\ufe0f Send a thank-you",
+        ]
+        st.sidebar.link_button(random.choice(labels), kofi_url)
+    else:
+        logger.warning(
+            "No support.kofi_url found in st.secrets; support button not shown."
+        )


### PR DESCRIPTION
## 🚀 Add Ko-fi Support Button to Sidebar

### Summary
This PR adds a dynamic "Support on Ko-fi" button to the Streamlit sidebar, enabling users to support ongoing development.

### Features
- Adds `render_support_link()` to `st_utils.py`
- Displays a Ko-fi button with a randomized CTA from a curated list:
  - ☕ Support on Ko-fi
  - 💖 Buy me a coffee
  - 🙏 Tip the dev
  - 🍩 Donate via Ko-fi
  - ❤️ Send a thank-you
- CTA is randomized once per session via `st.session_state`
- Reads Ko-fi URL from `st.secrets['support']['kofi_url']`
- Logs a warning if the URL is missing

### Setup
To enable:
```toml
# .streamlit/secrets.toml
[support]
kofi_url = "https://ko-fi.com/{profilename}"